### PR TITLE
build: added and enabled eslint plugin for react hooks

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -8,7 +8,7 @@
   "parserOptions": {
     "project": "./tsconfig.json"
   },
-  "plugins": ["@typescript-eslint"],
+  "plugins": ["@typescript-eslint", "react-hooks"],
   "rules": {
     "no-console": "off",
     "no-restricted-syntax": ["error", "ForInStatement", "LabeledStatement", "WithStatement"],
@@ -18,9 +18,8 @@
     "import/prefer-default-export": "off",
     "no-alert": "off",
     "spaced-comment": "off",
-    "import/extensions": "off"
-
-    // Предлагаю остальные правила не отключать. Они же не такие плохие, разве, нет?
-    // Но если будут сильно надоедать, то можем штучно исключать.
+    "import/extensions": "off",
+    "react-hooks/rules-of-hooks": "error", // Checks rules of Hooks
+    "react-hooks/exhaustive-deps": "warn" // Checks effect dependencies
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,7 @@
         "clean-webpack-plugin": "^4.0.0",
         "css-loader": "^6.5.0",
         "eslint": "^7.32.0",
+        "eslint-plugin-react-hooks": "^4.2.0",
         "html-webpack-plugin": "^5.5.0",
         "husky": "^7.0.4",
         "npm-run-all": "^4.1.5",
@@ -2830,7 +2831,6 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.2.0.tgz",
       "integrity": "sha512-623WEiZJqxR7VdxFCKLI6d6LLpwJkGPYKODnkH3D7WpOG5KM8yWueBd8TLsNAetEJNF5iJmolaAKO3F8yzyVBQ==",
-      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -11477,7 +11477,6 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.2.0.tgz",
       "integrity": "sha512-623WEiZJqxR7VdxFCKLI6d6LLpwJkGPYKODnkH3D7WpOG5KM8yWueBd8TLsNAetEJNF5iJmolaAKO3F8yzyVBQ==",
-      "peer": true,
       "requires": {}
     },
     "eslint-scope": {

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "clean-webpack-plugin": "^4.0.0",
     "css-loader": "^6.5.0",
     "eslint": "^7.32.0",
+    "eslint-plugin-react-hooks": "^4.2.0",
     "html-webpack-plugin": "^5.5.0",
     "husky": "^7.0.4",
     "npm-run-all": "^4.1.5",


### PR DESCRIPTION
Добавил в линтер правила, относительно `react-hooks`, как указано в документации:
https://reactjs.org/docs/hooks-rules.html

Я, кстати, не очень понял. Вообще ок ли такие мелкие ПР открывать?